### PR TITLE
Utilize Replace's return value

### DIFF
--- a/Cilsil/Extensions/MethodReferenceExtensions.cs
+++ b/Cilsil/Extensions/MethodReferenceExtensions.cs
@@ -28,8 +28,8 @@ namespace Cilsil.Extensions
             procName = methodReference.ReturnType.GetCompatibleFullName() + " " + procName;
             if (methodReference.DeclaringType != null)
             {
-                procName.Replace(methodReference.DeclaringType.FullName,
-                                 methodReference.DeclaringType.GetCompatibleFullName());
+                procName = procName.Replace(methodReference.DeclaringType.FullName,
+                                            methodReference.DeclaringType.GetCompatibleFullName());
             }
             return procName;
         }


### PR DESCRIPTION
Fixing a bug with non utilizing return value of string.Replace. As for now, method does nothing.