### PR TITLE
Refactors code to reduce technical debt - Use Pattern Matching

### DIFF
--- a/Cilsil/Cil/Parsers/UnboxParser.cs
+++ b/Cilsil/Cil/Parsers/UnboxParser.cs
@@ -40,8 +40,7 @@ namespace Cilsil.Cil.Parsers
                     }
                     else
                     {
-                        var type = instruction.Operand as TypeReference;
-                        if (type != null)
+                        if (instruction.Operand is TypeReference type)
                         {
                             var silType = Typ.FromTypeReferenceNoPointer(type);
                             var defaultBoxedValue = GetDefaultBoxedValue(silType);


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "Convert 'as' expression type check and the following null check into pattern matching"  [rule](https://www.jetbrains.com/help/resharper/UsePatternMatching.html)  reported by ReSharper.