### PR TITLE
ConstExpression Comparison Issue Fix

### DIFF
--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -96,7 +96,7 @@ namespace Cilsil.Cil.Parsers
         }
 
         /// <summary>
-        /// Registers a node in the CFG and set it as the successfor of the previous node.
+        /// Registers a node in the CFG and set it as the successor of the previous node.
         /// </summary>
         /// <param name="state">Current program state.</param>
         /// <param name="node">Node to register.</param>

--- a/Cilsil/Sil/Expressions/ConstExpression.cs
+++ b/Cilsil/Sil/Expressions/ConstExpression.cs
@@ -4,7 +4,6 @@ using Cilsil.Sil.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
-using System.Collections.Generic;
 
 namespace Cilsil.Sil.Expressions
 {
@@ -84,7 +83,7 @@ namespace Cilsil.Sil.Expressions
         /// </returns>
         public override bool Equals(object obj) =>
             obj is ConstExpression expression &&
-            EqualityComparer<object>.Default.Equals(ConstValue, expression.ConstValue) &&
+            CompareConstExpressionValue(ConstValue, expression.ConstValue) &&
             Kind == expression.Kind;
 
         /// <summary>
@@ -100,10 +99,10 @@ namespace Cilsil.Sil.Expressions
         /// Determines the type of the constant from its value.
         /// </summary>
         /// <param name="value">The value.</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="ConstKind"/> corresponding to the value.</returns>
         /// <exception cref="ArgumentException">@"Cannot infer constant kind from value of type 
         ///                            {value.GetType().ToString()}")</exception>
-        private ConstKind GetKindFromValue(object value)
+        private static ConstKind GetKindFromValue(object value)
         {
             switch (value)
             {
@@ -121,8 +120,38 @@ namespace Cilsil.Sil.Expressions
                 default:
                     throw new ArgumentException(
                         $@"Cannot infer constant kind from value of type 
-                           {value.GetType().ToString()}");
+                           {value.GetType()}");
             }
+        }
+
+        /// <summary>
+        /// Helper method for comparing values of a pair of <see cref="ConstExpression"/>.
+        /// </summary>
+        /// <param name="firstValue">The first value.</param>
+        /// <param name="secondValue">The second value.</param>
+        /// <returns><c>true</c> if the the values are equal, and <c>false</c> otherwise</returns>
+        private static bool CompareConstExpressionValue(object firstValue, object secondValue)
+        {
+            if (GetKindFromValue(firstValue) == GetKindFromValue(secondValue))
+            {
+                switch (firstValue)
+                {
+                    case IntRepresentation intRepresentation:
+                        return intRepresentation.Equals(secondValue);
+                    case ProcedureName procedureName:
+                        return procedureName.Equals(secondValue);
+                    case string _:
+                        return (string)firstValue == (string)secondValue;
+                    case float _:
+                    case double _:
+                        return (float)firstValue == (float)secondValue;
+                    case TypeName typeName:
+                        return typeName.Equals(secondValue);
+                    default:
+                        return false;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/Cilsil/Sil/Expressions/ConstExpression.cs
+++ b/Cilsil/Sil/Expressions/ConstExpression.cs
@@ -134,6 +134,7 @@ namespace Cilsil.Sil.Expressions
         {
             if (GetKindFromValue(firstValue) == GetKindFromValue(secondValue))
             {
+                var tolerance = 0.000000001;
                 switch (firstValue)
                 {
                     case IntRepresentation intRepresentation:
@@ -143,9 +144,9 @@ namespace Cilsil.Sil.Expressions
                     case string _:
                         return (string)firstValue == (string)secondValue;
                     case float _:
-                        return (float)firstValue == (float)secondValue;
+                        return Math.Abs((float)firstValue - (float)secondValue) < tolerance;
                     case double _:
-                        return (double)firstValue == (double)secondValue;
+                        return Math.Abs((double)firstValue - (double)secondValue) < tolerance;
                     case TypeName typeName:
                         return typeName.Equals(secondValue);
                     default:

--- a/Cilsil/Sil/Expressions/ConstExpression.cs
+++ b/Cilsil/Sil/Expressions/ConstExpression.cs
@@ -143,8 +143,9 @@ namespace Cilsil.Sil.Expressions
                     case string _:
                         return (string)firstValue == (string)secondValue;
                     case float _:
-                    case double _:
                         return (float)firstValue == (float)secondValue;
+                    case double _:
+                        return (double)firstValue == (double)secondValue;
                     case TypeName typeName:
                         return typeName.Equals(secondValue);
                     default:

--- a/Cilsil/Sil/IntRepresentation.cs
+++ b/Cilsil/Sil/IntRepresentation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Newtonsoft.Json;
+using System;
 
 namespace Cilsil.Sil
 {
@@ -41,6 +42,31 @@ namespace Cilsil.Sil
             Unsigned = unsigned;
             IsPointer = isPointer;
         }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="object" />, is equal to this 
+        /// instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="object" /> to compare with this 
+        /// instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; 
+        ///   otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj) =>
+            obj is IntRepresentation intRepresentation &&
+            Unsigned == intRepresentation.Unsigned &&
+            IsPointer == intRepresentation.IsPointer &&
+            Value == intRepresentation.Value;
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data 
+        /// structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode() => HashCode.Combine(Unsigned, IsPointer, Value);
 
         /// <summary>
         /// Converts to string.

--- a/Cilsil/Sil/ProcedureName.cs
+++ b/Cilsil/Sil/ProcedureName.cs
@@ -3,6 +3,7 @@
 using Cilsil.Extensions;
 using Mono.Cecil;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -125,6 +126,29 @@ namespace Cilsil.Sil
         }
 
         /// <summary>
+        /// Determines whether the specified <see cref="object" />, is equal to this 
+        /// instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="object" /> to compare with this 
+        /// instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; 
+        ///   otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is ProcedureName other)
+            {
+                return MethodName == other.MethodName &&
+                    Parameters.SequenceEqual(other.Parameters) &&
+                    ClassName == other.ClassName &&
+                    ReturnType == other.ReturnType &&
+                    IsStatic == other.IsStatic;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Converts to string.
         /// </summary>
         /// <returns>
@@ -146,5 +170,15 @@ namespace Cilsil.Sil
 
             return s;
         }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data 
+        /// structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode() => HashCode.Combine(
+            MethodName, Parameters, ClassName, ReturnType, IsStatic);
     }
 }


### PR DESCRIPTION
Resolves an issue in which constants weren't being compared correctly, which in turn manifests as nodes failing to be reused in translation when in fact they should have.

Tested:
Validated on simple example
TODO: Add CFG validation test framework