### PR TITLE
New resource leak unit test for 

### DIFF
--- a/Cilsil.Test/Assets/TestClass.cs
+++ b/Cilsil.Test/Assets/TestClass.cs
@@ -37,14 +37,9 @@ namespace Cilsil.Test.Assets
 
         public TestClass() { }
 
-        public TestClass(TestClass testClass)
+        public TestClass(string filename)
         {
-            InstanceObjectField = testClass;
-        }
-
-        public static void InvokeConstructorWithNullParam()
-        {
-            _ = new TestClass(null);
+            InstanceStreamReaderField = new StreamReader(filename);
         }
 
         /// <summary>
@@ -79,7 +74,7 @@ namespace Cilsil.Test.Assets
         }
 
         /// <summary>
-        /// Initializes the instance StreamReader field.
+        /// Close the instance StreamReader field interprocedurally.
         /// </summary>
         public void CleanupStreamReaderObjectField()
         {

--- a/Cilsil.Test/Assets/TestClass.cs
+++ b/Cilsil.Test/Assets/TestClass.cs
@@ -37,10 +37,22 @@ namespace Cilsil.Test.Assets
 
         public TestClass() { }
 
-        public TestClass(string filename)
+        public TestClass(TestClass testClass)
         {
+            InstanceObjectField = testClass;
+        }
+
+        public TestClass(TestClass testClass, string filename)
+        {
+            InstanceObjectField = testClass;
             InstanceStreamReaderField = new StreamReader(filename);
         }
+
+        public static void InvokeConstructorWithNullParam()
+        {
+            _ = new TestClass(null);
+        }
+        
 
         /// <summary>
         /// Initializes the instance TestClass field. In test cases, this method provides coverage

--- a/Cilsil.Test/Assets/TestClass.cs
+++ b/Cilsil.Test/Assets/TestClass.cs
@@ -79,6 +79,14 @@ namespace Cilsil.Test.Assets
         }
 
         /// <summary>
+        /// Initializes the instance StreamReader field.
+        /// </summary>
+        public void CleanupStreamReaderObjectField()
+        {
+            InstanceStreamReaderField.Close();
+        }
+
+        /// <summary>
         /// Initializes the static TestClass field. In test cases, this method provides coverage for
         /// stsfld.
         /// </summary>

--- a/Cilsil.Test/Assets/Utils.cs
+++ b/Cilsil.Test/Assets/Utils.cs
@@ -258,7 +258,7 @@ namespace Cilsil.Test.Assets
                     break;
                 case TestClassState.InitializedWithFilename:
                     output = Declare(VarType.TestClass, VarName.Tc) + Assign(VarName.Tc,
-                                                                             "new TestClass(\"whatever.txt\")");
+                                                                             "new TestClass(null, \"whatever.txt\")");
                     break;
                 case TestClassState.Null:
                     output = Declare(VarType.TestClass, VarName.Tc) + Assign(VarName.Tc, "null");

--- a/Cilsil.Test/Assets/Utils.cs
+++ b/Cilsil.Test/Assets/Utils.cs
@@ -66,6 +66,7 @@ namespace Cilsil.Test.Assets
         public enum TestClassMethod
         {
             None,
+            CleanupStreamReaderObjectField,
             ExpectNonNullParam,
             ReturnNullOnFalse,
             IncrementRefParameter,
@@ -346,6 +347,13 @@ namespace Cilsil.Test.Assets
                             "CloseStream requires one argument.");
                     }
                     return GetMethodCall(true);
+                case TestClassMethod.CleanupStreamReaderObjectField:
+                    if (args != null)
+                    {
+                        throw new ArgumentException(
+                            "CleanupStreamReaderObjectField requires no argument.");
+                    }
+                    return GetMethodCall(false);
                 case TestClassMethod.InitializeStreamReaderObjectField:
                     if (args != null)
                     {

--- a/Cilsil.Test/Assets/Utils.cs
+++ b/Cilsil.Test/Assets/Utils.cs
@@ -14,7 +14,7 @@ namespace Cilsil.Test.Assets
         /// <summary>
         /// The various states that a TestClass object in the tests can be in.
         /// </summary>
-        public enum TestClassState { None, Uninitialized, Null, Initialized };
+        public enum TestClassState { None, Uninitialized, Null, Initialized, InitializedWithFilename };
 
         /// <summary>
         /// The various kinds of Severity that appear in the tests.
@@ -255,6 +255,10 @@ namespace Cilsil.Test.Assets
                 case TestClassState.Initialized:
                     output = Declare(VarType.TestClass, VarName.Tc) + Assign(VarName.Tc,
                                                                              "new TestClass()");
+                    break;
+                case TestClassState.InitializedWithFilename:
+                    output = Declare(VarType.TestClass, VarName.Tc) + Assign(VarName.Tc,
+                                                                             "new TestClass(\"whatever.txt\")");
                     break;
                 case TestClassState.Null:
                     output = Declare(VarType.TestClass, VarName.Tc) + Assign(VarName.Tc, "null");

--- a/Cilsil.Test/E2E/NPETest.cs
+++ b/Cilsil.Test/E2E/NPETest.cs
@@ -147,10 +147,7 @@ namespace Cilsil.Test.E2E
         [DataTestMethod]
         public void ResourceLeakGlobalResourceInterproc(bool closeStream, InferError expectedError)
         {
-            TestRunManager.Run(InitVars(state: TestClassState.Initialized) +
-                               CallTestClassMethod(
-                                TestClassMethod.InitializeStreamReaderObjectField,
-                                true) + 
+            TestRunManager.Run(InitVars(state: TestClassState.InitializedWithFilename) + 
                                (closeStream ? CallTestClassMethod(
                                                 TestClassMethod.CleanupStreamReaderObjectField,
                                                 true)

--- a/Cilsil.Test/E2E/NPETest.cs
+++ b/Cilsil.Test/E2E/NPETest.cs
@@ -137,6 +137,28 @@ namespace Cilsil.Test.E2E
         }
 
         /// <summary>
+        /// Validates that a resource leak on an StreamReader initialized in the constructore is identified.
+        /// </summary>
+        /// <param name="closeStream"> If <c>true</c>, invokes the CleanupStreamReaderObjectField method; otherwise,
+        /// does not.</param>
+        /// <param name="expectedError">The kind of error expected to be reported by Infer.</param>
+        [DataRow(true, InferError.None)]
+        [DataRow(false, InferError.DOTNET_RESOURCE_LEAK)]
+        [DataTestMethod]
+        public void ResourceLeakGlobalResourceInterproc(bool closeStream, InferError expectedError)
+        {
+            TestRunManager.Run(InitVars(state: TestClassState.Initialized) +
+                               CallTestClassMethod(
+                                TestClassMethod.InitializeStreamReaderObjectField,
+                                true) + 
+                               (closeStream ? CallTestClassMethod(
+                                                TestClassMethod.CleanupStreamReaderObjectField,
+                                                true)
+                                            : string.Empty),
+                               GetString(expectedError));
+        }
+
+        /// <summary>
         /// Validates that there is no resource leak identified on a returned resource.
         /// </summary>
         /// <param name="returnsResource" If <c>true</c>, returns the instantiated resource; otherwise,


### PR DESCRIPTION
In this PR, we add a new unit test to reflect the [fix](https://github.com/facebook/infer/pull/1601) we had in backend, in which now an interprocedural cleanup function can close the dangling global resource. Such as the following example shows:

![image](https://user-images.githubusercontent.com/63893533/154333415-baec0b20-ba5d-4546-a5af-7e57068fee6d.png)
