### PR TITLE
Catch Translation Exceptions

### DIFF
--- a/Cilsil/Services/CfgParserService.cs
+++ b/Cilsil/Services/CfgParserService.cs
@@ -6,6 +6,7 @@ using Cilsil.Services.Results;
 using Cilsil.Sil;
 using Cilsil.Utils;
 using Mono.Cecil;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -57,7 +58,16 @@ namespace Cilsil.Services
             {
                 foreach (var method in Methods)
                 {
-                    ComputeMethodCfg(method);
+                    try
+                    {
+                        ComputeMethodCfg(method);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.WriteError(e.Message);
+                        Log.RecordUnfinishedMethod(method.GetCompatibleFullName(),
+                                                   method.Body.Instructions.Count);
+                    }
                     i++;
                     bar.Report((double)i / total);
                     if (WriteConsoleProgress)


### PR DESCRIPTION
This modification handles and logs exceptions that can sometimes occur during a method's CFG computation. This prevents ungraceful crash of the pipeline in these events. Response to the [issue](https://github.com/microsoft/infersharp/issues/130).