### PR TITLE
Variable Name Bug Fix

### DIFF
--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -811,7 +811,7 @@ namespace Cilsil.Cil.Parsers
         /// <returns>The string representation.</returns>
         protected string LocalName(int index, MethodDefinition method) =>
             method.DebugInformation.TryGetName(method.Body.Variables[index], out var name) && 
-            name != "CS$0$0000" ? 
+            !name.Contains("CS$") ? 
                 name : $"%{index}";
 
         /// <summary>

--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -810,7 +810,9 @@ namespace Cilsil.Cil.Parsers
         /// <param name="method">The method in which the variable is located.</param>
         /// <returns>The string representation.</returns>
         protected string LocalName(int index, MethodDefinition method) =>
-            method.DebugInformation.TryGetName(method.Body.Variables[index], out var name) ? name : $"%{index}";
+            method.DebugInformation.TryGetName(method.Body.Variables[index], out var name) && 
+            name != "CS$0$0000" ? 
+                name : $"%{index}";
 
         /// <summary>
         /// Gets the argument name for the given index and method.

--- a/Cilsil/Services/CfgParserService.cs
+++ b/Cilsil/Services/CfgParserService.cs
@@ -6,6 +6,7 @@ using Cilsil.Services.Results;
 using Cilsil.Sil;
 using Cilsil.Utils;
 using Mono.Cecil;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -57,7 +58,16 @@ namespace Cilsil.Services
             {
                 foreach (var method in Methods)
                 {
-                    ComputeMethodCfg(method);
+                    try
+                    {
+                        ComputeMethodCfg(method);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.WriteError(e.Message);
+                        Log.RecordUnfinishedMethod(method.GetCompatibleFullName(),
+                                                   method.Body.Instructions.Count);
+                    }
                     i++;
                     bar.Report((double)i / total);
                     if (WriteConsoleProgress)


### PR DESCRIPTION
The original way of retrieving variable names from the PDB occasionally retrieved variables with name "CS$0$0000". This could erroneously cause Infer to interpret an LvarExpression as a temporary frontend value, which caused analysis crash. We resolve that issue here. 