### PR TITLE
Deregister Resources on Translation Exception

### DIFF
--- a/Cilsil/Services/CfgParserService.cs
+++ b/Cilsil/Services/CfgParserService.cs
@@ -166,7 +166,7 @@ namespace Cilsil.Services
                             break;
                         }
                     } while (programState.HasInstruction);
-                } 
+                }
                 catch (Exception e)
                 {
                     translationUnfinished = true;


### PR DESCRIPTION
This patches a bug in which resources were not being deregistered in the event of an exception being thrown. This later creates issues in which InferAnalyzeJson fails to correctly parse the cfg (in particular, the ID is mismatched). 