### PR TITLE
Fix False Positive Null Dereferences on Reference Primitives

### DIFF
--- a/Cilsil.Test/Assets/TestClass.cs
+++ b/Cilsil.Test/Assets/TestClass.cs
@@ -299,6 +299,25 @@ namespace Cilsil.Test.Assets
             throw new IOException();
         }
 
+        public bool AssignZeroByReference(out int result)
+        {
+            result = 0;
+            return false;
+        }
+
+        public bool InvokesAssignZeroAndDerefs(out int result)
+        {
+            if (!AssignZeroByReference(out result))
+            {
+                result = GetHashCode();
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
         /// <summary>
         /// If input <c>true</c>, a certain exception is thrown which when caught results in a null 
         /// object being returned; otherwise, an instantiated object is returned.

--- a/Cilsil.Test/Assets/TestClass.cs
+++ b/Cilsil.Test/Assets/TestClass.cs
@@ -305,6 +305,9 @@ namespace Cilsil.Test.Assets
             return false;
         }
 
+        // This method is used to identify a case in which we were creating a false positive null
+        // dereference, as a result of passing a reference to result to AssignZeroByReference
+        // rather than its value.
         public bool InvokesAssignZeroAndDerefs(out int result)
         {
             if (!AssignZeroByReference(out result))

--- a/Cilsil/Cil/Parsers/CallParser.cs
+++ b/Cilsil/Cil/Parsers/CallParser.cs
@@ -61,6 +61,22 @@ namespace Cilsil.Cil.Parsers
                                  out var retId,
                                  out var callArgs,
                                  out var callInstr);
+                foreach (var arg in callArgs)
+                {
+                    // If the argument is already passed a reference, we don't want to pass it by
+                    // reference to another another method; pass as value type.
+                    if (arg.Type is Address address &&
+                        address.AddressType == Address.ReferenceKind.Parameter)
+                    {
+                        var freshIdentifier = state.GetIdentifier(Identifier.IdentKind.Normal);
+                        var valueExp = new VarExpression(freshIdentifier);
+                        instrs.Add(new Load(freshIdentifier, 
+                                            arg.Expression, 
+                                            arg.Type, 
+                                            state.CurrentLocation));
+                        arg.Expression = valueExp;
+                    }
+                }
 
                 instrs.Add(callInstr);
 

--- a/Cilsil/Sil/Instructions/Call.cs
+++ b/Cilsil/Sil/Instructions/Call.cs
@@ -95,7 +95,7 @@ namespace Cilsil.Sil.Instructions
             /// <summary>
             /// The argument expression.
             /// </summary>
-            public Expression Expression { get; }
+            public Expression Expression { get; set; }
 
             /// <summary>
             /// The argument type.


### PR DESCRIPTION
We were observing false positive null derefs in the following case:

assign(out int x) {
    x = 0;
}

useAssign(out int x) {
    assign(x);
    x = GetHashCode();
}

This was because the original translation invoked assign(&x) rather than assign(x); in other words, it passed a reference to a parameter already passed by reference, rather than the correct behavior of passing the value of a parameter passed by reference. 