### PR TITLE
Set Exit Node to Last Location of Method

### DIFF
--- a/Cilsil/Sil/ProcedureDescription.cs
+++ b/Cilsil/Sil/ProcedureDescription.cs
@@ -115,7 +115,7 @@ namespace Cilsil.Sil
             ExitNode = new ExitNode(Location.FromSequencePoint(methodDefinition
                                                                .DebugInformation
                                                                .SequencePoints
-                                                               .FirstOrDefault()),
+                                                               .LastOrDefault()),
                                     this);
             ExceptionSinkNode = new StatementNode(location,
                                                   StatementNode.StatementNodeKind.ExceptionsSink,


### PR DESCRIPTION
This minor fix sets the exit node to the end of the method, rather than at the beginning, which is how it should be:

![image](https://user-images.githubusercontent.com/38902361/176979392-2ca84839-e110-499f-8d00-e2aa9b47221d.png)
