### PR TITLE
Bug Fix for Wrong Dereference on Instance Method with Address-type Object

### DIFF
--- a/Cilsil/Cil/Parsers/CallParser.cs
+++ b/Cilsil/Cil/Parsers/CallParser.cs
@@ -87,7 +87,8 @@ namespace Cilsil.Cil.Parsers
                 {
                     var thisArg = callArgs.First();
                     if (thisArg.Expression is VarExpression varExpression &&
-                        !varExpression.FromThis)
+                        !varExpression.FromThis &&
+                        !(thisArg.Type is Address))
                     {
                         instrs.Insert(0, CreateDereference(varExpression, thisArg.Type, state));
                     }


### PR DESCRIPTION
This PR fixes a bug in which a dereference was being inserted for an instance method's object when it is an address type. Normally, it should be simply applied to the instance itself; we erroneously were doing so when the instance in question was an address 