### PR TITLE
Inline Instructions for Initializing Boolean Instance Field to Default Value

### DIFF
--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -671,8 +671,8 @@ namespace Cilsil.Cil.Parsers
         /// <param name="fieldReference">A <see cref="FieldReference"/> which describes the field
         /// for which the expression is being created.</param>
         /// <returns>The <see cref="LfieldExpression"/> for the given field.</returns>
-        protected static LfieldExpression CreateFieldExpression(Expression fieldParentExpression,
-                                                                FieldReference fieldReference)
+        public static LfieldExpression CreateFieldExpression(Expression fieldParentExpression,
+                                                             FieldReference fieldReference)
         {
             return new LfieldExpression(fieldParentExpression,
                                         new FieldIdentifier(fieldReference.GetCompatibleFullName(),

--- a/Cilsil/Services/CfgParserService.cs
+++ b/Cilsil/Services/CfgParserService.cs
@@ -93,6 +93,16 @@ namespace Cilsil.Services
             return Execute();
         }
 
+        /// <summary>
+        /// This method should be invoked before translation of a program begins, if applicable. 
+        /// It is intended for the default initialization of boolean fields to false in the 
+        /// construction of an object, in the absence of there being IL that actually performs this
+        /// (this can happen for uninitialized boolean fields). The purpose of adding this is to
+        /// combat false positive resource leaks that can occur when users declare IDisposable 
+        /// objects with a boolean field indicating whether the object has already been disposed.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
         private CfgNode InitializeInstanceBooleanFields(ProgramState state)
         {
             var objectFields = state.Method.DeclaringType.Fields;


### PR DESCRIPTION
This PR implements an inlining of instructions for initializing boolean instance field values to their default values. This is a targeted translation update to eliminate false positive resource leaks that can occur for resources that conditionally dispose depending on the value of an uninitialized boolean field (which in C# means a default initialization to false). 

The test case for this is included in https://github.com/microsoft/infersharp/pull/159